### PR TITLE
Fixed legacy method call for 2.0 compatibility Fixes #6

### DIFF
--- a/class/category_link.php
+++ b/class/category_link.php
@@ -177,7 +177,7 @@ class ImtaggingCategory_linkHandler extends icms_ipf_Handler {
 		$moduleObj = icms_getModuleInfo($handler->_moduleName);
 
 		$criteria = new icms_db_criteria_Compo();
-		$criteria->add(new icms_db_criteria_Item('category_link_mid', $moduleObj->mid()));
+		$criteria->add(new icms_db_criteria_Item('category_link_mid', $moduleObj->getVar('mid')));
 		$criteria->add(new icms_db_criteria_Item('category_link_item', $handler->_itemname));
 		$criteria->add(new icms_db_criteria_Item('category_link_cid', $cid));
 		$sql = 'SELECT category_link_iid FROM ' . $this->table;

--- a/class/form/elements/imtaggingmoduleelement.php
+++ b/class/form/elements/imtaggingmoduleelement.php
@@ -21,9 +21,9 @@ class ImtaggingModuleElement extends icms_form_elements_Select {
 		$criteria->setSort('name');
 		$modulesObj = $module_handler->getObjects($criteria);
 		foreach ($modulesObj as $moduleObj) {
-			$moduleObj->loadInfo($moduleObj->dirname());
+			$moduleObj->loadInfo($moduleObj->getVar('dirname'));
 			if (isset($moduleObj->modinfo['object_items'])) {
-				$modules_array[$moduleObj->mid()] = $moduleObj->name();
+			    $modules_array[$moduleObj->getVar('mid')] = $moduleObj->getVar('name');
 			}
 		}
 		$this->addOptionArray(array(


### PR DESCRIPTION
legacy methods dirname(), name(), and mid() have been removed. The universal method getVar() takes their place